### PR TITLE
feat: support marshal slice type if's not proto message

### DIFF
--- a/jsonpb.go
+++ b/jsonpb.go
@@ -49,6 +49,11 @@ func (j *JSONPb) marshalTo(w io.Writer, v interface{}) error {
 	return (*jsonpb.Marshaler)(j).Marshal(w, p)
 }
 
+var (
+	// protoMessageType is stored to prevent constant lookup of the same type at runtime.
+	protoMessageType = reflect.TypeOf((*proto.Message)(nil)).Elem()
+)
+
 // marshalNonProto marshals a non-message field of a protobuf message.
 // This function does not correctly marshals arbitary data structure into JSON,
 // but it is only capable of marshaling non-message field values of protobuf,
@@ -61,6 +66,40 @@ func (j *JSONPb) marshalNonProtoField(v interface{}) ([]byte, error) {
 			return []byte("null"), nil
 		}
 		rv = rv.Elem()
+	}
+
+	if rv.Kind() == reflect.Slice {
+		if rv.IsNil() {
+			if j.EmitDefaults {
+				return []byte("[]"), nil
+			}
+			return []byte("null"), nil
+		}
+
+		if rv.Type().Elem().Implements(protoMessageType) {
+			var buf bytes.Buffer
+			err := buf.WriteByte('[')
+			if err != nil {
+				return nil, err
+			}
+			for i := 0; i < rv.Len(); i++ {
+				if i != 0 {
+					err = buf.WriteByte(',')
+					if err != nil {
+						return nil, err
+					}
+				}
+				if err = (*jsonpb.Marshaler)(j).Marshal(&buf, rv.Index(i).Interface().(proto.Message)); err != nil {
+					return nil, err
+				}
+			}
+			err = buf.WriteByte(']')
+			if err != nil {
+				return nil, err
+			}
+
+			return buf.Bytes(), nil
+		}
 	}
 
 	if rv.Kind() == reflect.Map {

--- a/jsonpb_test.go
+++ b/jsonpb_test.go
@@ -1,0 +1,38 @@
+package gateway
+
+import (
+	"testing"
+)
+
+func TestMarshalNonProtoSliceField(t *testing.T) {
+	type testData struct {
+		List []string
+	}
+
+	data := testData{}
+	j := &JSONPb{}
+
+	t.Run("disable EmitDefaults", func(t *testing.T) {
+		j.EmitDefaults = false
+
+		r, err := j.Marshal(data.List)
+		if err != nil {
+			t.Errorf("Marshal failed with %v", err)
+		}
+		if want := "null"; want != string(r) {
+			t.Errorf("want (%v), got (%v)", want, string(r))
+		}
+	})
+
+	t.Run("enable EmitDefaults", func(t *testing.T) {
+		j.EmitDefaults = true
+
+		r, err := j.Marshal(data.List)
+		if err != nil {
+			t.Errorf("Marshal failed with %v", err)
+		}
+		if want := "[]"; want != string(r) {
+			t.Errorf("want (%v), got (%v)", want, string(r))
+		}
+	})
+}


### PR DESCRIPTION
marshals "v" into JSON if type is slice will be return "null", but expect result is "[]". 

code is copy from: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/runtime/marshal_jsonpb.go#L84